### PR TITLE
Added default value (false) for params.umidedup in main.nf

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -35,6 +35,7 @@ include multiqc from './modules/multiqc/multiqc.nf'
 --------------------------------------------------------------------------------------*/
 
 params.input = "$baseDir/test/data/metadata.csv"
+params.umidedup = false
 // params.input = "metadata.csv"
 
 //params.reads = "$baseDir/test/data/reads/*.fq.gz"


### PR DESCRIPTION
Just added the default value (false) for params.umidedup into main.nf, so this parameter is defined when using the Crick profile.