### PR TITLE
Packages - fix dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ WORKDIR /home/paraclu-9
 RUN make && cp paraclu /home/bin/paraclu && cp paraclu-cut.sh /home/bin/paraclu-cut.sh
 
 # Install PEKA
+WORKDIR /home
 RUN wget https://raw.githubusercontent.com/ulelab/imaps/master/src/imaps/sandbox/kmers.py 
 RUN mkdir src && mv kmers.py src/kmers.py
 


### PR DESCRIPTION
Fix the dockerfile by changing the folder to "home" before downloading peka.py and making a src directory.